### PR TITLE
Run Laravel dev server in app container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
             - .:/var/www
         ports:
             - "8000:8000"
+        command: php artisan serve --host=0.0.0.0 --port=8000
         depends_on:
             - mysql
 


### PR DESCRIPTION
## Summary
- configure the app service to start the Laravel built-in server so port 8000 serves the application

## Testing
- docker compose up --build -d *(fails: docker not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb61886548324936d8a9c39434b61