### PR TITLE
Implement clean architecture for offers with API and web flows

### DIFF
--- a/app/Application/Offer/CreateOffer.php
+++ b/app/Application/Offer/CreateOffer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Application\Offer;
+
+use App\DTO\Offer\OfferData;
+use App\Domain\Offer\Repositories\OfferRepositoryInterface;
+use App\Models\Offer;
+
+class CreateOffer
+{
+    public function __construct(
+        private readonly OfferRepositoryInterface $offers,
+    ) {
+    }
+
+    public function execute(OfferData $data): Offer
+    {
+        return $this->offers->create($data);
+    }
+}

--- a/app/Application/Offer/DeleteOffer.php
+++ b/app/Application/Offer/DeleteOffer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Application\Offer;
+
+use App\Domain\Offer\Repositories\OfferRepositoryInterface;
+use App\Models\Offer;
+
+class DeleteOffer
+{
+    public function __construct(
+        private readonly OfferRepositoryInterface $offers,
+    ) {
+    }
+
+    public function execute(Offer $offer): void
+    {
+        $this->offers->delete($offer);
+    }
+}

--- a/app/Application/Offer/ListOffers.php
+++ b/app/Application/Offer/ListOffers.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Application\Offer;
+
+use App\DTO\Offer\OfferFilterData;
+use App\Domain\Offer\Repositories\OfferRepositoryInterface;
+use Illuminate\Database\Eloquent\Collection;
+
+class ListOffers
+{
+    public function __construct(
+        private readonly OfferRepositoryInterface $offers,
+    ) {
+    }
+
+    public function execute(OfferFilterData $filters): Collection
+    {
+        return $this->offers->list($filters);
+    }
+}

--- a/app/Domain/Offer/Repositories/OfferRepositoryInterface.php
+++ b/app/Domain/Offer/Repositories/OfferRepositoryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Domain\Offer\Repositories;
+
+use App\DTO\Offer\OfferData;
+use App\DTO\Offer\OfferFilterData;
+use App\Models\Offer;
+use Illuminate\Database\Eloquent\Collection;
+
+interface OfferRepositoryInterface
+{
+    public function list(OfferFilterData $filters): Collection;
+
+    public function create(OfferData $data): Offer;
+
+    public function delete(Offer $offer): void;
+}

--- a/app/Http/Controllers/Api/OfferController.php
+++ b/app/Http/Controllers/Api/OfferController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Application\Offer\CreateOffer;
+use App\Application\Offer\DeleteOffer;
+use App\Application\Offer\ListOffers;
+use App\DTO\Offer\OfferData;
+use App\DTO\Offer\OfferFilterData;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Offer\OfferIndexRequest;
+use App\Http\Requests\Offer\OfferStoreRequest;
+use App\Http\Resources\OfferResource;
+use App\Models\Offer;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
+
+class OfferController extends Controller
+{
+    public function __construct(
+        private readonly ListOffers $listOffers,
+        private readonly CreateOffer $createOffer,
+        private readonly DeleteOffer $deleteOffer,
+    ) {
+    }
+
+    public function index(OfferIndexRequest $request): JsonResponse
+    {
+        $filters = OfferFilterData::fromArray($request->validated());
+
+        $offers = $this->listOffers->execute($filters);
+
+        return OfferResource::collection($offers)
+            ->response()
+            ->setStatusCode(HttpResponse::HTTP_OK);
+    }
+
+    public function store(OfferStoreRequest $request): JsonResponse
+    {
+        $offer = $this->createOffer->execute(OfferData::fromArray($request->validated()));
+
+        return OfferResource::make($offer)
+            ->response()
+            ->setStatusCode(HttpResponse::HTTP_CREATED);
+    }
+
+    public function destroy(Offer $offer): JsonResponse
+    {
+        $this->deleteOffer->execute($offer);
+
+        return response()->json(null, HttpResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/app/Infrastructure/Persistence/Offer/EloquentOfferRepository.php
+++ b/app/Infrastructure/Persistence/Offer/EloquentOfferRepository.php
@@ -1,22 +1,23 @@
 <?php
 
-namespace App\Services\Offer;
+namespace App\Infrastructure\Persistence\Offer;
 
 use App\DTO\Offer\OfferData;
 use App\DTO\Offer\OfferFilterData;
+use App\Domain\Offer\Repositories\OfferRepositoryInterface;
 use App\Models\Offer;
 use Illuminate\Database\Eloquent\Collection;
 
-class OfferService
+class EloquentOfferRepository implements OfferRepositoryInterface
 {
     public function __construct(
-        private readonly Offer $offer,
+        private readonly Offer $model,
     ) {
     }
 
     public function list(OfferFilterData $filters): Collection
     {
-        $query = $this->offer->newQuery()
+        $query = $this->model->newQuery()
             ->orderByDesc('start_date');
 
         if ($filters->hasSearch()) {
@@ -33,7 +34,7 @@ class OfferService
 
     public function create(OfferData $data): Offer
     {
-        return $this->offer->newQuery()->create($data->toArray());
+        return $this->model->newQuery()->create($data->toArray());
     }
 
     public function delete(Offer $offer): void

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Domain\Offer\Repositories\OfferRepositoryInterface;
+use App\Infrastructure\Persistence\Offer\EloquentOfferRepository;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(OfferRepositoryInterface::class, EloquentOfferRepository::class);
     }
 
     /**

--- a/database/factories/OfferFactory.php
+++ b/database/factories/OfferFactory.php
@@ -16,8 +16,19 @@ class OfferFactory extends Factory
      */
     public function definition(): array
     {
+        $startDate = $this->faker->dateTimeBetween('-1 month', '+1 month');
+        $endDate = $this->faker->boolean(60)
+            ? $this->faker->dateTimeBetween($startDate, '+3 months')
+            : null;
+
         return [
-            //
+            'title' => $this->faker->sentence(3),
+            'description' => $this->faker->paragraph(),
+            'price' => $this->faker->randomFloat(2, 10, 1000),
+            'currency' => $this->faker->randomElement(['BRL', 'USD', 'EUR']),
+            'status' => $this->faker->randomElement(['draft', 'active', 'expired']),
+            'start_date' => $startDate,
+            'end_date' => $endDate,
         ];
     }
 }

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -39,7 +39,9 @@
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
-        @vite(['resources/js/app.ts', "resources/js/pages/{$page['component']}.vue"])
+        @unless (app()->environment('testing'))
+            @vite(['resources/js/app.ts', "resources/js/pages/{$page['component']}.vue"])
+        @endunless
         @inertiaHead
     </head>
     <body class="font-sans antialiased">

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Controllers\OfferController;
+use App\Http\Controllers\Api\OfferController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('api')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Controllers\OfferController;
+use App\Http\Controllers\Web\OfferController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    public function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}

--- a/tests/Feature/Offer/OfferApiTest.php
+++ b/tests/Feature/Offer/OfferApiTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Offer;
+
+use App\Models\Offer;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class OfferApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_lists_offers(): void
+    {
+        Offer::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/offers');
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(3, 'data');
+    }
+
+    public function test_it_filters_offers_using_search_parameter(): void
+    {
+        Offer::factory()->create([
+            'title' => 'Promoção Especial',
+        ]);
+
+        Offer::factory()->create([
+            'title' => 'Oferta secundária',
+        ]);
+
+        $response = $this->getJson('/api/offers?search=promoção');
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.title', 'Promoção Especial');
+    }
+
+    public function test_it_creates_a_new_offer(): void
+    {
+        $payload = [
+            'title' => 'Nova Oferta',
+            'description' => 'Descrição detalhada da oferta',
+            'price' => 199.9,
+            'currency' => 'BRL',
+            'status' => 'active',
+            'start_date' => Carbon::now()->toIso8601String(),
+            'end_date' => Carbon::now()->addDay()->toIso8601String(),
+        ];
+
+        $response = $this->postJson('/api/offers', $payload);
+
+        $response
+            ->assertCreated()
+            ->assertJsonPath('data.title', 'Nova Oferta')
+            ->assertJsonPath('data.currency', 'BRL');
+
+        $this->assertDatabaseHas('offers', [
+            'title' => 'Nova Oferta',
+            'currency' => 'BRL',
+        ]);
+    }
+
+    public function test_it_deletes_an_offer(): void
+    {
+        $offer = Offer::factory()->create();
+
+        $response = $this->deleteJson("/api/offers/{$offer->id}");
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseMissing('offers', [
+            'id' => $offer->id,
+        ]);
+    }
+}

--- a/tests/Feature/Offer/OfferWebTest.php
+++ b/tests/Feature/Offer/OfferWebTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\Offer;
+
+use App\Models\Offer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class OfferWebTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_view_offers_page(): void
+    {
+        $user = User::factory()->create();
+        Offer::factory()->count(2)->create();
+
+        $response = $this->actingAs($user)->get(route('test-page'));
+
+        $response->assertOk();
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('TestPage')
+            ->has('offers', 2)
+            ->has('filters', fn (Assert $props) => $props
+                ->where('search', null)
+            )
+        );
+    }
+
+    public function test_authenticated_user_can_create_offer_through_web_form(): void
+    {
+        $user = User::factory()->create();
+
+        $startDate = Carbon::now()->addHour();
+        $endDate = (clone $startDate)->addHour();
+
+        $payload = [
+            'title' => 'Oferta Web',
+            'description' => 'Oferta criada via formulário web',
+            'price' => '99.90',
+            'currency' => 'BRL',
+            'status' => 'draft',
+            'start_date' => $startDate->toDateTimeLocalString(),
+            'end_date' => $endDate->toDateTimeLocalString(),
+        ];
+
+        $response = $this->actingAs($user)->post(route('offers.store'), $payload);
+
+        $response
+            ->assertRedirect(route('test-page'))
+            ->assertSessionHas('success', 'Oferta criada com sucesso.');
+
+        $this->assertDatabaseHas('offers', [
+            'title' => 'Oferta Web',
+            'currency' => 'BRL',
+        ]);
+    }
+
+    public function test_authenticated_user_can_delete_an_offer(): void
+    {
+        $user = User::factory()->create();
+        $offer = Offer::factory()->create();
+
+        $response = $this->actingAs($user)->delete(route('offers.destroy', $offer));
+
+        $response
+            ->assertRedirect(route('test-page'))
+            ->assertSessionHas('success', 'Oferta removida com sucesso.');
+
+        $this->assertDatabaseMissing('offers', [
+            'id' => $offer->id,
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- introduce offer use cases and repository binding to support both API and web controllers following clean architecture
- update routes and Inertia layout to work across environments and prevent Vite manifest errors in tests
- expand offer factory and add feature tests covering API and web offer operations

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68d4260950e08324b5b17bb2a05e216b